### PR TITLE
Update packages, fix build break,  update default key endpoint URLs

### DIFF
--- a/Windows/BasicConsoleSample/App.config
+++ b/Windows/BasicConsoleSample/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Windows/BasicConsoleSample/BasicConsoleSample.csproj
+++ b/Windows/BasicConsoleSample/BasicConsoleSample.csproj
@@ -36,18 +36,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.CognitiveServices.Vision.Face, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.CognitiveServices.Vision.Face.2.4.0-preview\lib\net452\Microsoft.Azure.CognitiveServices.Vision.Face.dll</HintPath>
+    <Reference Include="Microsoft.Azure.CognitiveServices.Vision.Face, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.CognitiveServices.Vision.Face.2.8.0-preview.2\lib\net452\Microsoft.Azure.CognitiveServices.Vision.Face.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.19\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.23\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime.Azure, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Rest.ClientRuntime.Azure.3.3.19\lib\net452\Microsoft.Rest.ClientRuntime.Azure.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="OpenCvSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6adad1e807fea099, processorArchitecture=MSIL">
       <HintPath>..\packages\OpenCvSharp3-AnyCPU.3.1.0.20160622\lib\net45\OpenCvSharp.dll</HintPath>
@@ -110,12 +109,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\OpenCvSharp3-AnyCPU.3.1.0.20160622\build\OpenCvSharp3-AnyCPU.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\OpenCvSharp3-AnyCPU.3.1.0.20160622\build\OpenCvSharp3-AnyCPU.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Windows/BasicConsoleSample/Program.cs
+++ b/Windows/BasicConsoleSample/Program.cs
@@ -42,8 +42,9 @@ namespace BasicConsoleSample
 {
     internal class Program
     {
+        // Update these values before running the application
         const string ApiKey = "<your Face API key>";
-        const string Endpoint = "<your Face API endpoint>"; // For example https://westus-face-key.cognitiveservices.azure.com/
+        const string Endpoint = "<your Face API endpoint>";
 
         private static void Main(string[] args)
         {

--- a/Windows/BasicConsoleSample/Program.cs
+++ b/Windows/BasicConsoleSample/Program.cs
@@ -48,7 +48,8 @@ namespace BasicConsoleSample
         private static void Main(string[] args)
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            // Create grabber. 
+
+            // Create grabber.
             FrameGrabber<DetectedFace[]> grabber = new FrameGrabber<DetectedFace[]>();
 
             // Create Face API Client.
@@ -67,11 +68,12 @@ namespace BasicConsoleSample
             grabber.AnalysisFunction = async frame =>
             {
                 Console.WriteLine($"Submitting frame acquired at {frame.Metadata.Timestamp}");
-                // Encode image and submit to Face API. 
+
+                // Encode image and submit to Face API.
                 return (await faceClient.Face.DetectWithStreamAsync(frame.Image.ToMemoryStream(".jpg"))).ToArray();
             };
 
-            // Set up a listener for when we receive a new result from an API call. 
+            // Set up a listener for when we receive a new result from an API call.
             grabber.NewResultAvailable += (s, e) =>
             {
                 if (e.TimedOut)

--- a/Windows/BasicConsoleSample/Program.cs
+++ b/Windows/BasicConsoleSample/Program.cs
@@ -42,8 +42,8 @@ namespace BasicConsoleSample
 {
     internal class Program
     {
-        const string ApiKey = "<your API key>";
-        const string Endpoint = "https://westus.api.cognitive.microsoft.com";
+        const string ApiKey = "<your Face API key>";
+        const string Endpoint = "<your Face API endpoint>"; // For example https://westus-face-key.cognitiveservices.azure.com/
 
         private static void Main(string[] args)
         {

--- a/Windows/BasicConsoleSample/packages.config
+++ b/Windows/BasicConsoleSample/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.CognitiveServices.Vision.Face" version="2.4.0-preview" targetFramework="net452" />
+  <package id="Microsoft.Azure.CognitiveServices.Vision.Face" version="2.8.0-preview.2" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net452" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
-  <package id="Microsoft.Rest.ClientRuntime" version="2.3.19" targetFramework="net452" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.23" targetFramework="net452" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.19" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net452" />
   <package id="OpenCvSharp3-AnyCPU" version="3.1.0.20160622" targetFramework="net452" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />
 </packages>

--- a/Windows/LiveCameraSample/App.config
+++ b/Windows/LiveCameraSample/App.config
@@ -15,7 +15,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.ProjectOxford.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Windows/LiveCameraSample/LiveCameraSample.csproj
+++ b/Windows/LiveCameraSample/LiveCameraSample.csproj
@@ -38,21 +38,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.CognitiveServices.Vision.ComputerVision.5.0.0\lib\net452\Microsoft.Azure.CognitiveServices.Vision.ComputerVision.dll</HintPath>
+    <Reference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision, Version=7.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.CognitiveServices.Vision.ComputerVision.7.0.1\lib\net452\Microsoft.Azure.CognitiveServices.Vision.ComputerVision.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.CognitiveServices.Vision.Face, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.CognitiveServices.Vision.Face.2.4.0-preview\lib\net452\Microsoft.Azure.CognitiveServices.Vision.Face.dll</HintPath>
+    <Reference Include="Microsoft.Azure.CognitiveServices.Vision.Face, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.CognitiveServices.Vision.Face.2.8.0-preview.2\lib\net452\Microsoft.Azure.CognitiveServices.Vision.Face.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.19\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.23\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime.Azure, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Rest.ClientRuntime.Azure.3.3.19\lib\net452\Microsoft.Rest.ClientRuntime.Azure.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="OpenCvSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6adad1e807fea099, processorArchitecture=MSIL">
       <HintPath>..\packages\OpenCvSharp3-AnyCPU.3.1.0.20160622\lib\net45\OpenCvSharp.dll</HintPath>

--- a/Windows/LiveCameraSample/MainWindow.xaml.cs
+++ b/Windows/LiveCameraSample/MainWindow.xaml.cs
@@ -133,7 +133,7 @@ namespace LiveCameraSample
                         string apiName = "";
                         string message = e.Exception.Message;
                         var faceEx = e.Exception as FaceAPI.Models.APIErrorException;
-                        var visionEx = e.Exception as VisionAPI.Models.ComputerVisionErrorException;
+                        var visionEx = e.Exception as VisionAPI.Models.ComputerVisionErrorResponseException;
                         if (faceEx != null)
                         {
                             apiName = "Face";

--- a/Windows/LiveCameraSample/Properties/Settings.Designer.cs
+++ b/Windows/LiveCameraSample/Properties/Settings.Designer.cs
@@ -118,7 +118,7 @@ namespace LiveCameraSample.Properties {
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("https://westus.api.cognitive.microsoft.com")]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://westus-face-key.cognitiveservices.azure.com")]
         public string FaceAPIHost {
             get {
                 return ((string)(this["FaceAPIHost"]));
@@ -130,7 +130,7 @@ namespace LiveCameraSample.Properties {
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("https://westus.api.cognitive.microsoft.com")]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://westus-vision-key.cognitiveservices.azure.com")]
         public string VisionAPIHost {
             get {
                 return ((string)(this["VisionAPIHost"]));

--- a/Windows/LiveCameraSample/Properties/Settings.Designer.cs
+++ b/Windows/LiveCameraSample/Properties/Settings.Designer.cs
@@ -118,7 +118,7 @@ namespace LiveCameraSample.Properties {
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("https://westus-face-key.cognitiveservices.azure.com")]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://westus.api.cognitive.microsoft.com")]
         public string FaceAPIHost {
             get {
                 return ((string)(this["FaceAPIHost"]));
@@ -130,7 +130,7 @@ namespace LiveCameraSample.Properties {
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("https://westus-vision-key.cognitiveservices.azure.com")]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://westus.api.cognitive.microsoft.com")]
         public string VisionAPIHost {
             get {
                 return ((string)(this["VisionAPIHost"]));

--- a/Windows/LiveCameraSample/packages.config
+++ b/Windows/LiveCameraSample/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" version="5.0.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.CognitiveServices.Vision.Face" version="2.4.0-preview" targetFramework="net452" />
+  <package id="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" version="7.0.1" targetFramework="net452" />
+  <package id="Microsoft.Azure.CognitiveServices.Vision.Face" version="2.8.0-preview.2" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
-  <package id="Microsoft.Rest.ClientRuntime" version="2.3.19" targetFramework="net452" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.23" targetFramework="net452" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.19" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net452" />
   <package id="OpenCvSharp3-AnyCPU" version="3.1.0.20160622" targetFramework="net452" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />
 </packages>

--- a/Windows/VideoFrameAnalyzer/ConcurrentLogger.cs
+++ b/Windows/VideoFrameAnalyzer/ConcurrentLogger.cs
@@ -46,14 +46,16 @@ namespace VideoFrameAnalyzer
         public static void WriteLine(string message)
         {
             var timestamp = DateTime.Now;
+
             // Push the message on the queue
             s_messageQueue.Add(timestamp.ToString("o") + ": " + message);
+
             // Start a new task that will dequeue one message and print it. The tasks will not
             // necessarily run in order, but since each task just takes the oldest message and
-            // prints it, the messages will print in order. 
+            // prints it, the messages will print in order.
             Task.Run(async () =>
             {
-                // Wait to get access to the queue. 
+                // Wait to get access to the queue.
                 await s_printMutex.WaitAsync();
                 try
                 {

--- a/Windows/VideoFrameAnalyzer/VideoFrameAnalyzer.csproj
+++ b/Windows/VideoFrameAnalyzer/VideoFrameAnalyzer.csproj
@@ -33,9 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="OpenCvSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6adad1e807fea099, processorArchitecture=MSIL">
       <HintPath>..\packages\OpenCvSharp3-AnyCPU.3.1.0.20160622\lib\net45\OpenCvSharp.dll</HintPath>

--- a/Windows/VideoFrameAnalyzer/packages.config
+++ b/Windows/VideoFrameAnalyzer/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net452" />
   <package id="OpenCvSharp3-AnyCPU" version="3.1.0.20160622" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
* Update to latest NuGet packages
* Fix build break due to Exception name change (ComputerVisionErrorException changed to ComputerVisionErrorResponseException)
* Make it clear that Face Key is needed in the BasicConsoleSample, and give example of key endpoint URL (I thought a Vision key was needed there... it was not clear)
* Make sure there is a space line above comment line
* Remove some spaces at the end of comment lines

Tested two projects by running on my PC with a live camera