### PR TITLE
Remove sensitive attributes and set returnFaceId to false

### DIFF
--- a/Windows/BasicConsoleSample/Program.cs
+++ b/Windows/BasicConsoleSample/Program.cs
@@ -42,8 +42,11 @@ namespace BasicConsoleSample
 {
     internal class Program
     {
-        const string ApiKey = "<your API key>";
-        const string Endpoint = "https://westus.api.cognitive.microsoft.com";
+        //const string ApiKey = "<your API key>";
+        //const string Endpoint = "https://westus.api.cognitive.microsoft.com";
+        const string ApiKey = "eb0380ed7781462aaf0343b2e4b568f2";
+        //const string ApiKey = "85cd1a634d94423680d341a0146d3993";
+        const string Endpoint = "https://faceontest.cognitiveservices.azure.com";
 
         private static void Main(string[] args)
         {
@@ -68,7 +71,8 @@ namespace BasicConsoleSample
             {
                 Console.WriteLine($"Submitting frame acquired at {frame.Metadata.Timestamp}");
                 // Encode image and submit to Face API. 
-                return (await faceClient.Face.DetectWithStreamAsync(frame.Image.ToMemoryStream(".jpg"))).ToArray();
+                var image = frame.Image.ToMemoryStream(".jpg");
+                return (await faceClient.Face.DetectWithStreamAsync(image, returnFaceId: false)).ToArray();
             };
 
             // Set up a listener for when we receive a new result from an API call. 

--- a/Windows/LiveCameraSample/Aggregation.cs
+++ b/Windows/LiveCameraSample/Aggregation.cs
@@ -34,41 +34,22 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.Azure.CognitiveServices.Vision.Face.Models;
 
 namespace LiveCameraSample
 {
     internal class Aggregation
     {
-        public static KeyValuePair<string, double> GetDominantEmotion(Emotion scores)
-        {
-            return new Dictionary<string, double>()
-                {
-                    { "Anger", scores.Anger },
-                    { "Contempt", scores.Contempt },
-                    { "Disgust", scores.Disgust },
-                    { "Fear", scores.Fear },
-                    { "Happiness", scores.Happiness },
-                    { "Neutral", scores.Neutral },
-                    { "Sadness", scores.Sadness },
-                    { "Surprise", scores.Surprise }
-                }
-                .OrderByDescending(kv => kv.Value)
-                .ThenBy(kv => kv.Key)
-                .First();
-        }
-
-        public static string SummarizeEmotion(Emotion scores)
-        {
-            var bestEmotion = Aggregation.GetDominantEmotion(scores);
-            return string.Format("{0}: {1:N1}", bestEmotion.Key, bestEmotion.Value);
-        }
-
         public static string SummarizeFaceAttributes(FaceAttributes attr)
         {
             List<string> attrs = new List<string>();
-            if (attr.Gender.HasValue) attrs.Add(attr.Gender.Value.ToString());
-            if (attr.Age > 0) attrs.Add(attr.Age.ToString());
+
+            if (attr.Glasses != null)
+            {
+                attrs.Add($"Glasses: {attr.Glasses}");
+            }
+
             if (attr.HeadPose != null)
             {
                 // Simple rule to estimate whether person is facing camera. 

--- a/Windows/LiveCameraSample/Visualization.cs
+++ b/Windows/LiveCameraSample/Visualization.cs
@@ -120,11 +120,6 @@ namespace LiveCameraSample
                     if (face.FaceAttributes != null)
                     {
                         summary.Append(Aggregation.SummarizeFaceAttributes(face.FaceAttributes));
-
-                        if (face.FaceAttributes.Emotion != null)
-                        {
-                            summary.Append(Aggregation.SummarizeEmotion(face.FaceAttributes.Emotion));
-                        }
                     }
 
                     if (celebName?[i] != null)


### PR DESCRIPTION
New users don't have permission to use senstive attributes and recognition functionalities So we remove these feature in the demo to ensure that new users can run this demo successfully